### PR TITLE
✨(reg. routine) add support for a quantile output mode

### DIFF
--- a/src/torch_uncertainty/routines/regression.py
+++ b/src/torch_uncertainty/routines/regression.py
@@ -1,6 +1,7 @@
 import warnings
 from collections.abc import Callable
 
+import torch
 from einops import rearrange
 from lightning.pytorch import LightningModule
 from lightning.pytorch.loggers import Logger
@@ -41,6 +42,7 @@ class RegressionRoutine(LightningModule):
         loss: nn.Module | None = None,
         dist_family: str | None = None,
         dist_estimate: str | DistEstimate = "mean",
+        quantiles: list[float] | None = None,
         *,
         is_ensemble: bool = False,
         optim_recipe: Callable[[nn.Module], OptimizerLRScheduler]
@@ -60,6 +62,7 @@ class RegressionRoutine(LightningModule):
             output_dim: Number of outputs of the model.
             loss: Loss function to optimize the :attr:`model`. Defaults to ``None``.
             dist_family: Distribution family to use for probabilistic regression. If ``None``, performs point-wise regression. Defaults to ``None``.
+            quantiles: Quantile levels :math:`\tau \in (0, 1)` to predict, in increasing order. If ``None``, the routine does not use the quantile output mode. Mutually exclusive with :attr:`dist_family`. The head closest to :math:`\tau=0.5` is used as the point estimate for MAE/MSE/RMSE. Defaults to ``None``.
             dist_estimate: The estimate to use when computing point-wise metrics. Defaults to ``mean``.
             is_ensemble: Whether the model is an ensemble. Defaults to ``False``.
             optim_recipe: The optimizer and optionally the scheduler to use, or a callable that returns them. Defaults to ``None``.
@@ -94,6 +97,13 @@ class RegressionRoutine(LightningModule):
         self.dist_family = dist_family
         self.dist_estimate = DistEstimate(dist_estimate)
         self.probabilistic = dist_family is not None
+        self.quantiles = quantiles
+        self.quantile_mode = quantiles is not None
+        if self.quantile_mode:
+            _quantile_routine_checks(quantiles, self.probabilistic)
+            self.register_buffer("quantile_levels", torch.as_tensor(quantiles, dtype=torch.float))
+            # index of the head used as the point estimate for MAE/MSE/RMSE
+            self.median_index = int(torch.argmin((self.quantile_levels - 0.5).abs()).item())
         self.output_dim = output_dim
         self.loss = loss
         self.is_ensemble = is_ensemble
@@ -201,6 +211,10 @@ class RegressionRoutine(LightningModule):
                     "The model is probabilistic: the output must be a dictionary ",
                     "of PyTorch distribution parameters.",
                 )
+        elif self.quantile_mode:
+            # The last dimension indexes the quantile levels and must be preserved,
+            # even when a single level is requested.
+            pass
         else:
             if self.one_dim_regression:
                 pred = pred.squeeze(-1)
@@ -266,8 +280,13 @@ class RegressionRoutine(LightningModule):
             preds = get_dist_estimate(dist, self.dist_estimate)
             return preds, dist
 
-        preds = rearrange(preds, "(m b) c -> b m c", b=batch_size)
-        return preds.mean(dim=1), None
+        preds = rearrange(preds, "(m b) c -> b m c", b=batch_size).mean(dim=1)
+        if self.quantile_mode:
+            # Keep the full quantile predictions available for quantile metrics
+            # (see #327) and expose the median head as the point estimate.
+            self.last_quantile_preds = preds
+            return preds[:, self.median_index].unsqueeze(-1), None
+        return preds, None
 
     def validation_step(self, batch: tuple[Tensor, Tensor]) -> None:
         """Perform a single validation step based on the input tensors.
@@ -395,3 +414,22 @@ def _regression_routine_checks(output_dim: int) -> None:
     """
     if output_dim < 1:
         raise ValueError(f"output_dim must be positive, got {output_dim}.")
+
+
+def _quantile_routine_checks(quantiles: list[float], probabilistic: bool) -> None:
+    """Check the quantile levels requested for the quantile output mode.
+
+    Args:
+        quantiles: the requested quantile levels.
+        probabilistic: whether the routine is already in probabilistic mode.
+    """
+    if probabilistic:
+        raise ValueError("`dist_family` and `quantiles` are mutually exclusive.")
+    if len(quantiles) == 0:
+        raise ValueError("quantiles must not be empty.")
+    if any(not 0 < q < 1 for q in quantiles):
+        raise ValueError(f"quantiles must lie in (0, 1), got {quantiles}.")
+    if list(quantiles) != sorted(quantiles):
+        raise ValueError(f"quantiles must be sorted in increasing order, got {quantiles}.")
+    if len(set(quantiles)) != len(quantiles):
+        raise ValueError(f"quantiles must not contain duplicates, got {quantiles}.")

--- a/tests/routines/test_regression.py
+++ b/tests/routines/test_regression.py
@@ -6,7 +6,7 @@ from torch import nn
 
 from tests._dummies import DummyRegressionBaseline, DummyRegressionDataModule
 from torch_uncertainty import TUTrainer
-from torch_uncertainty.losses import DistributionNLLLoss, ELBOLoss
+from torch_uncertainty.losses import DistributionNLLLoss, ELBOLoss, PinballLoss
 from torch_uncertainty.optim_recipes import optim_cifar10_resnet18
 from torch_uncertainty.routines import RegressionRoutine
 
@@ -183,6 +183,53 @@ class TestRegression:
         trainer.fit(model, dm)
         trainer.validate(model, dm)
         trainer.test(model, dm)
+
+    def test_quantile_mode(self) -> None:
+        """The quantile output mode stores the levels and routes the median head."""
+        routine = RegressionRoutine(
+            output_dim=1,
+            model=nn.Linear(4, 3),
+            loss=PinballLoss(quantile=0.5),
+            quantiles=[0.1, 0.5, 0.9],
+        )
+        assert routine.quantile_mode
+        assert not routine.probabilistic
+        assert routine.median_index == 1
+
+        inputs = torch.randn(8, 4)
+        # the quantile axis must be preserved by the forward pass
+        assert routine(inputs).shape == (8, 3)
+
+        preds, dist = routine.evaluation_forward(inputs)
+        assert dist is None
+        assert preds.shape == (8, 1)
+        assert routine.last_quantile_preds.shape == (8, 3)
+        # the point estimate is the median head
+        assert torch.allclose(preds.squeeze(-1), routine.last_quantile_preds[:, 1])
+
+    def test_quantile_mode_single_level(self) -> None:
+        """A single quantile level must not collapse the quantile axis."""
+        routine = RegressionRoutine(
+            output_dim=1,
+            model=nn.Linear(4, 1),
+            loss=PinballLoss(quantile=0.5),
+            quantiles=[0.5],
+        )
+        assert routine.median_index == 0
+        assert routine(torch.randn(8, 4)).shape == (8, 1)
+
+    def test_quantile_mode_failures(self) -> None:
+        common = {"output_dim": 1, "model": nn.Identity(), "loss": nn.MSELoss()}
+        with pytest.raises(ValueError, match=r"mutually exclusive"):
+            RegressionRoutine(dist_family="normal", quantiles=[0.5], **common)
+        with pytest.raises(ValueError, match=r"must not be empty"):
+            RegressionRoutine(quantiles=[], **common)
+        with pytest.raises(ValueError, match=r"must lie in \(0, 1\)"):
+            RegressionRoutine(quantiles=[0.0, 0.5], **common)
+        with pytest.raises(ValueError, match=r"must be sorted"):
+            RegressionRoutine(quantiles=[0.9, 0.1], **common)
+        with pytest.raises(ValueError, match=r"must not contain duplicates"):
+            RegressionRoutine(quantiles=[0.5, 0.5], **common)
 
     def test_regression_failures(self) -> None:
         with pytest.raises(ValueError, match=r"output_dim must be positive"):


### PR DESCRIPTION
Draft for #326, following @alafage's suggestion in #327 to land the quantile
output mode first and keep the quantile metrics for a separate PR.

## Summary
Adds a `quantiles` argument to `RegressionRoutine`, enabling a quantile output
mode alongside the existing point-wise and probabilistic modes:

- `quantiles` stores the tau-grid and is registered as a buffer, so it follows the
  module across devices.
- `forward` preserves the trailing quantile axis, including when a single level
  is requested (a plain `squeeze(-1)` would silently collapse it).
- `evaluation_forward` aggregates over the ensemble axis as before, keeps the
  full quantile predictions available, and returns the head closest to tau=0.5 as
  the point estimate, so `MAE`/`MSE`/`RMSE` keep working unchanged.
- `_quantile_routine_checks` validates the levels (non-empty, within (0, 1),
  strictly increasing, no duplicates) and rejects combining `quantiles` with
  `dist_family`.

`training_step` needed no change: `PinballLoss` consumes the
`(batch, n_quantiles)` tensor directly through the existing non-probabilistic
branch.

## Scope
No new metrics here - mean pinball, CRPS and the coverage-from-quantiles
variant of `QuantileCalibrationError` will follow in the #327 PR, implemented as
separate classes as requested.

## Open questions for review
1. `evaluation_forward` currently stashes the full quantile tensor on
   `self.last_quantile_preds` so the future quantile metrics can reach it.
   Would you prefer extending the return signature instead?
2. Ensemble aggregation averages the quantiles over the model axis. This is the
   usual approximation, but averaging quantiles is not the same as the quantiles
   of the mixture - happy to switch to another aggregation if you have a
   preference.
3. `quantiles` is placed before the keyword-only marker to mirror `dist_family`.
   Let me know if you would rather have it keyword-only.

## Tests
Three tests added to `tests/routines/test_regression.py` covering the nominal
path, the single-level case, and the validation failures. `pytest
tests/routines/test_regression.py` passes (9 tests), and `ruff check` /
`ruff format --check` are clean.

## Note on the `rqr` branch
I noticed the `rqr` branch moves `PinballLoss` from `losses/regression.py` to a
new `losses/quantile.py` alongside `RQRLoss`. This PR only touches
`routines/regression.py`, and the tests import `PinballLoss` from
`torch_uncertainty.losses`, so it should be unaffected either way - happy to
rebase once that lands.