### PR TITLE
Add parameterized probability adjustment

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -443,6 +443,7 @@ Scaling Methods
     MatrixScaler
     DirichletScaler
     IsotonicRegressionScaler
+    PPAScaler
 
 
 Conformal Methods

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -340,6 +340,16 @@ For isotonic regression calibration, consider citing:
 * Authors: *Bianca Zadrozny and Charles Elkan*
 * Paper: `KDD 2002 <https://dl.acm.org/doi/10.1145/775047.775151>`__
 
+Parameterized Probability Adjustment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For Parameterized Probability Adjustment, consider citing:
+
+**Calibrating Random Forests**
+
+* Author: *Henrik Boström*
+* Paper: `ICMLA 2008 <https://doi.org/10.1109/ICMLA.2008.107>`__
+
 Monte-Carlo Batch Normalization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/torch_uncertainty/post_processing/__init__.py
+++ b/src/torch_uncertainty/post_processing/__init__.py
@@ -6,6 +6,7 @@ from .calibration import (
     HistogramBinningScaler,
     IsotonicRegressionScaler,
     MatrixScaler,
+    PPAScaler,
     TemperatureScaler,
     VectorScaler,
 )

--- a/src/torch_uncertainty/post_processing/calibration/__init__.py
+++ b/src/torch_uncertainty/post_processing/calibration/__init__.py
@@ -4,5 +4,6 @@ from .dirichlet_scaler import DirichletScaler
 from .histogram_binning import HistogramBinningScaler
 from .isotonic_regression import IsotonicRegressionScaler
 from .matrix_scaler import MatrixScaler
+from .ppa import PPAScaler
 from .temperature_scaler import TemperatureScaler
 from .vector_scaler import VectorScaler

--- a/src/torch_uncertainty/post_processing/calibration/ppa.py
+++ b/src/torch_uncertainty/post_processing/calibration/ppa.py
@@ -1,0 +1,128 @@
+import logging
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.utils.data import DataLoader
+
+from torch_uncertainty.post_processing import PostProcessing
+
+from .utils import _determine_dimensionality, _extract_data
+
+
+class PPAScaler(PostProcessing):
+    r"""Parameterized Probability Adjustment (PPA) calibration.
+
+    PPA sharpens a probability vector :math:`\mathbf{p}` towards
+    :math:`\mathbf{p}_0`, which distributes a mass of one uniformly over the
+    classes tied for the highest probability:
+
+    .. math::
+        \mathbf{p}_{\mathrm{PPA}} = r\mathbf{p}_0 + (1-r)\mathbf{p}.
+
+    The adjustment :math:`r \in [0, 1]` is fitted on the calibration set by
+    minimising the Brier score. PPA was introduced to correct the tendency of
+    random forests of probability estimation trees to produce probabilities
+    biased towards the uniform distribution.
+
+    Args:
+        model: Model to calibrate. Defaults to ``None``.
+        eps: Small value for stability when converting probabilities back to
+            logits. Defaults to ``1e-6``.
+        device: Device to use for tensor operations. Defaults to ``None``.
+
+    References:
+        [1] `Boström, H. (2008). Calibrating Random Forests. ICMLA 2008
+        <https://doi.org/10.1109/ICMLA.2008.107>`_.
+        [2] `Shaker, M. H., & Hüllermeier, E. (2025). Random Forest
+        Calibration. Knowledge-Based Systems
+        <https://doi.org/10.1016/j.knosys.2025.114143>`_.
+    """
+
+    num_classes: int
+    adjustment: Tensor
+
+    def __init__(
+        self,
+        model: nn.Module | None = None,
+        eps: float = 1e-6,
+        device: Literal["cpu", "cuda"] | torch.device | None = None,
+    ) -> None:
+        super().__init__(model)
+        if not 0 < eps < 0.5:
+            raise ValueError(f"eps must be strictly between 0 and 0.5. Got {eps}.")
+
+        self.eps = eps
+        self.device = device
+        self.register_buffer("adjustment", torch.tensor(0.0, device=device))
+
+    @staticmethod
+    def _target_distribution(probs: Tensor) -> Tensor:
+        """Return the uniform distribution over the most probable classes."""
+        maxima = probs.amax(dim=-1, keepdim=True)
+        max_mask = probs == maxima
+        return max_mask / max_mask.sum(dim=-1, keepdim=True)
+
+    def fit(self, dataloader: DataLoader, progress: bool = True) -> None:
+        """Fit the PPA adjustment on calibration data.
+
+        Args:
+            dataloader: Dataloader providing the calibration data.
+            progress: Whether to show a progress bar. Defaults to ``True``.
+        """
+        if self.model is None or isinstance(self.model, nn.Identity):  # coverage: ignore
+            logging.warning(
+                "model is None. Fitting post_processing method on the dataloader's data directly."
+            )
+            self.model = nn.Identity()
+
+        all_logits, all_labels = _extract_data(
+            dataloader=dataloader, model=self.model, device=self.device, progress=progress
+        )
+        self.num_classes, probs, labels = _determine_dimensionality(all_logits, all_labels)
+
+        if self.num_classes == 1:
+            probs = torch.stack((1 - probs, probs), dim=-1)
+            num_label_classes = 2
+        else:
+            num_label_classes = self.num_classes
+
+        labels_one_hot = F.one_hot(labels.long(), num_label_classes).to(probs.dtype)
+        target_probs = self._target_distribution(probs)
+        direction = target_probs - probs
+        denominator = direction.square().sum()
+
+        # Closed-form least-squares solution for the Brier objective.
+        if denominator == 0:
+            adjustment = torch.zeros_like(denominator)
+        else:
+            numerator = (direction * (labels_one_hot - probs)).sum()
+            adjustment = (numerator / denominator).clamp(0, 1)
+
+        self.adjustment.copy_(adjustment)
+        self.trained = True
+
+    @torch.no_grad()
+    def forward(self, inputs: Tensor) -> Tensor:
+        """Apply PPA and return calibrated logits."""
+        if self.model is None:  # coverage: ignore
+            raise ValueError("Provide a model before calling forward.")
+        if not self.trained:
+            logging.warning("Scaler not trained. Returning raw predictions.")
+            return self.model(inputs)
+
+        logits = self.model(inputs)
+        if self.num_classes == 1:
+            positive_probs = torch.sigmoid(logits).flatten()
+            probs = torch.stack((1 - positive_probs, positive_probs), dim=-1)
+        else:
+            probs = torch.softmax(logits, dim=-1)
+
+        target_probs = self._target_distribution(probs)
+        calibrated_probs = self.adjustment * target_probs + (1 - self.adjustment) * probs
+        calibrated_probs = calibrated_probs.clamp(self.eps, 1 - self.eps)
+
+        if self.num_classes == 1:
+            return torch.logit(calibrated_probs[:, 1], eps=self.eps).view_as(logits)
+        return torch.log(calibrated_probs)

--- a/tests/post_processing/test_scalers.py
+++ b/tests/post_processing/test_scalers.py
@@ -9,6 +9,7 @@ from torch_uncertainty.post_processing import (
     HistogramBinningScaler,
     IsotonicRegressionScaler,
     MatrixScaler,
+    PPAScaler,
     TemperatureScaler,
     VectorScaler,
 )
@@ -288,6 +289,90 @@ class TestHistogramBinningScaler:
         # Output should be stable and normalized probabilities
         calib_probs = torch.softmax(calib_logits, dim=-1)
         torch.testing.assert_close(calib_probs.sum(dim=-1), torch.ones(len(inputs)))
+
+
+class TestPPAScaler:
+    """Testing the PPAScaler class."""
+
+    def test_main(self) -> None:
+        scaler = PPAScaler(model=nn.Identity())
+        logits = torch.tensor([[-1.0, 1.0]])
+
+        assert not scaler.trained
+        assert torch.equal(scaler(logits), logits)
+
+        for eps in (0, 0.5, 1):
+            with pytest.raises(ValueError, match=r"eps must be strictly between 0 and 0\.5"):
+                PPAScaler(eps=eps)
+
+    def test_fit_binary(self) -> None:
+        probability = torch.tensor(0.6)
+        inputs = torch.logit(probability).repeat(10)
+        labels = torch.tensor([1] * 8 + [0] * 2)
+        dataloader = DataLoader(list(zip(inputs, labels, strict=True)), batch_size=10)
+
+        scaler = PPAScaler(model=nn.Identity())
+        scaler.fit(dataloader, progress=False)
+
+        calibrated_probs = torch.sigmoid(scaler(inputs))
+        torch.testing.assert_close(scaler.adjustment, torch.tensor(0.5))
+        torch.testing.assert_close(calibrated_probs, torch.full_like(inputs, 0.8))
+        assert scaler(inputs.unsqueeze(-1)).shape == (10, 1)
+        assert torch.mean((calibrated_probs - labels) ** 2) < torch.mean(
+            (probability - labels) ** 2
+        )
+
+    def test_fit_multiclass(self, multiclass_dataloader) -> None:
+        scaler = PPAScaler(model=nn.Identity())
+        scaler.fit(multiclass_dataloader, progress=False)
+
+        inputs, _ = next(iter(multiclass_dataloader))
+        calibrated_probs = torch.softmax(scaler(inputs), dim=-1)
+
+        assert scaler.num_classes == 3
+        torch.testing.assert_close(scaler.adjustment, torch.tensor(1.0))
+        assert torch.equal(calibrated_probs.argmax(dim=-1), inputs.argmax(dim=-1))
+        torch.testing.assert_close(
+            calibrated_probs.sum(dim=-1), torch.ones(calibrated_probs.shape[0])
+        )
+
+    def test_adjustment_lower_bound(self) -> None:
+        probability = torch.tensor(0.8)
+        inputs = torch.logit(probability).repeat(10)
+        labels = torch.tensor([1] * 5 + [0] * 5)
+        dataloader = DataLoader(list(zip(inputs, labels, strict=True)), batch_size=10)
+        scaler = PPAScaler(model=nn.Identity())
+
+        scaler.fit(dataloader, progress=False)
+
+        torch.testing.assert_close(scaler.adjustment, torch.tensor(0.0))
+        torch.testing.assert_close(torch.sigmoid(scaler(inputs)), probability.expand_as(inputs))
+
+    def test_uniform_probabilities(self) -> None:
+        inputs = torch.zeros((6, 3))
+        labels = torch.tensor([0, 1, 2, 0, 1, 2])
+        dataloader = DataLoader(list(zip(inputs, labels, strict=True)), batch_size=6)
+        scaler = PPAScaler(model=nn.Identity())
+
+        scaler.fit(dataloader, progress=False)
+
+        torch.testing.assert_close(scaler.adjustment, torch.tensor(0.0))
+        torch.testing.assert_close(
+            torch.softmax(scaler(inputs), dim=-1), torch.full_like(inputs, 1 / 3)
+        )
+
+    def test_tied_maxima(self) -> None:
+        inputs = torch.log(torch.tensor([[0.4, 0.4, 0.2]])).repeat(6, 1)
+        labels = torch.tensor([0, 1, 0, 1, 0, 1])
+        dataloader = DataLoader(list(zip(inputs, labels, strict=True)), batch_size=6)
+        scaler = PPAScaler(model=nn.Identity())
+
+        scaler.fit(dataloader, progress=False)
+        calibrated_probs = torch.softmax(scaler(inputs), dim=-1)
+
+        torch.testing.assert_close(scaler.adjustment, torch.tensor(1.0))
+        torch.testing.assert_close(calibrated_probs[:, 0], calibrated_probs[:, 1])
+        assert torch.all(calibrated_probs[:, 2] < 1e-5)
 
 
 class TestBBQScaler:


### PR DESCRIPTION
## Description

Fixes #256.

Adds `PPAScaler`, which applies the scalar PPA transform from equation (15) of Shaker and Hüllermeier (2025). It fits `r` in `[0, 1]` by minimising the Brier score. The minimiser is computed in closed form, so the method needs no optimiser or new dependency.

For each prediction, PPA moves probability mass towards the most likely class. If several classes tie, they share the target mass. The scaler accepts binary and multiclass logits through the existing post-processing API, then returns calibrated logits.

Tests cover both coefficient bounds, an interior value, tied maxima, uniform predictions, binary output shape, multiclass normalisation and preservation of the predicted class.

## Testing

- `MPLBACKEND=Agg python -m pytest -q`: 728 passed
- `python -m pytest tests/post_processing/test_scalers.py -q`: 27 passed
- `ruff check` and `ruff format --check` on the changed Python files: passed
- `pre-commit run --files <changed files>`: passed
- Sphinx HTML build with warnings treated as errors: passed

Focused coverage could not be collected locally because Coverage 7.15.2 terminates while importing PyTorch 2.13.0. The focused tests pass under Python 3.12 and 3.13 without coverage instrumentation.

## Checklist

- [x] Branch name is not `main` or `dev`
- [x] Tests pass locally (`uv run pytest tests`)
- [x] Code is formatted (`uv run ruff format && uv run ruff check --fix`)
- [ ] Code coverage is not reduced too much
- [x] New functions/classes have type annotations and docstrings
- [x] If a new method is implemented, a reference to the paper is added to the [References page](https://torch-uncertainty.github.io/references.html)
- [x] Licensed code from external sources is explicitly attributed